### PR TITLE
Updated to go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7 as builder
+FROM golang:1.23.8 as builder
 
 WORKDIR /fskick-api
 

--- a/cmd/server/static/static.go
+++ b/cmd/server/static/static.go
@@ -2,5 +2,5 @@ package static
 
 import "embed"
 
-//go:embed *
+//go:embed css js
 var Dir embed.FS

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/spie/fskick
 
-go 1.22.0
-
-toolchain go1.22.6
+go 1.23.8
 
 require (
 	github.com/a-h/templ v0.2.747
@@ -21,7 +19,6 @@ require (
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,10 +47,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
-golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180816055513-1c9583448a9c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,7 +23,7 @@ func (server *Server) Get(route string, handler func(http.ResponseWriter, *http.
 }
 
 func (server *Server) HandleStatic(static embed.FS) {
-	server.mux.Handle("GET /static/*", http.StripPrefix("/static/", http.FileServerFS(static)))
+	server.mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(static)))
 }
 
 func (server *Server) Run() error {


### PR DESCRIPTION
Use go 1.23 in Docker
Fix handling static files for go 1.23